### PR TITLE
TASK-33: Loan form UX, snackbar when accordions disabled

### DIFF
--- a/src/components/form/EarlyPaymentsForm.tsx
+++ b/src/components/form/EarlyPaymentsForm.tsx
@@ -12,6 +12,7 @@ import { useLocalization } from '@/providers/LocalizationProvider';
 import InputNumberFormat from '@/components/ui/InputNumberFormat';
 import Select from '@/components/ui/Select';
 import Input from '@/components/ui/Input';
+import { popup } from '@telegram-apps/sdk-react';
 import { formOpts, withForm } from '@/hooks/useLoanForm';
 import { earlyPaymentSchema } from '@/schemas/earlyPayment';
 import { loanDetailsSchema } from '@/schemas/loanDetails';
@@ -20,6 +21,7 @@ import {
   hapticSuccess,
   hapticSelection,
   hapticDestructive,
+  hapticWarning,
 } from '@/utils/haptic';
 
 const typeLabels: Record<string, string> = {
@@ -68,6 +70,11 @@ const EarlyPaymentsForm = withForm({
                   if (isLoanDetailsValid) {
                     hapticSelection();
                     setSectionOpen((prev) => !prev);
+                  } else {
+                    hapticWarning();
+                    if (popup.isSupported()) {
+                      popup.show({ message: t('fillLoanDetailsFirst') });
+                    }
                   }
                 }}
               >
@@ -85,7 +92,7 @@ const EarlyPaymentsForm = withForm({
                     </form.Field>
                   </>
                 </Accordion.Summary>
-                <Accordion.Content style={{ background: 'transparent' }}>
+                <Accordion.Content>
                   <form.Field name='earlyPayments' mode='array'>
                     {(field) => {
                       const expandedItem =

--- a/src/components/form/LoanDetailsForm.tsx
+++ b/src/components/form/LoanDetailsForm.tsx
@@ -1,5 +1,5 @@
-import { memo } from 'react';
-import { List, Section } from '@telegram-apps/telegram-ui';
+import { memo, useState } from 'react';
+import { Accordion, List, Section } from '@telegram-apps/telegram-ui';
 import { useLocalization } from '@/providers/LocalizationProvider';
 import InputNumberFormat from '@/components/ui/InputNumberFormat';
 import Select from '@/components/ui/Select';
@@ -10,97 +10,112 @@ const LoanDetailsForm = withForm({
   ...formOpts,
   render: function Render({ form }) {
     const { t, language } = useLocalization();
+    const [additionalOpen, setAdditionalOpen] = useState(false);
 
     return (
-      <Section header={t('loanDetails')}>
-        <List>
-          <form.Field
-            name={'loanAmount'}
-            children={(field) => (
-              <InputNumberFormat
-                header={t('loanAmount')}
-                placeholder={t('loanAmount')}
-                field={field}
-                inputMode='decimal'
-                maximumFractionDigits={2}
-              />
-            )}
-          />
-          <form.Field
-            name={'interestRate'}
-            children={(field) => (
-              <InputNumberFormat
-                header={t('interestRate')}
-                placeholder={t('interestRate')}
-                field={field}
-                format='percent'
-                inputMode='decimal'
-                maximumFractionDigits={2}
-              />
-            )}
-          />
-          <form.Field
-            name={'loanTerm'}
-            children={(field) => (
-              <InputNumberFormat
-                format='unit'
-                unit='year'
-                locales={language}
-                header={t('loanTerm')}
-                placeholder={t('loanTerm')}
-                field={field}
-                inputMode='numeric'
-                maximumIntegerDigits={2}
-              />
-            )}
-          />
-          <form.Field
-            name={'startDate'}
-            children={(field) => (
-              <Input
-                header={t('startDate')}
-                placeholder={t('startDate')}
-                field={field}
-                type='date'
-              />
-            )}
-          />
-          <form.Field
-            name={'paymentType'}
-            children={(field) => (
-              <Select
-                header={t('paymentType')}
-                field={field}
-                options={[
-                  {
-                    label: t('annuityPayment'),
-                    value: 'annuity',
-                  },
-                  {
-                    label: t('differentiatedPayment'),
-                    value: 'differentiated',
-                  },
-                ]}
-              />
-            )}
-          />
-          <form.Field
-            name={'paymentDay'}
-            children={(field) => (
-              <Select
-                header={t('paymentDay')}
-                field={field}
-                options={Array.from({ length: 31 }, (_, i) => i + 1).map(
-                  (day) => ({
-                    label: String(day),
-                    value: String(day),
-                  })
-                )}
-              />
-            )}
-          />
-        </List>
-      </Section>
+      <>
+        <Section header={t('loanDetails')}>
+          <List>
+            <form.Field
+              name={'loanAmount'}
+              children={(field) => (
+                <InputNumberFormat
+                  header={t('loanAmount')}
+                  placeholder={t('loanAmount')}
+                  field={field}
+                  inputMode='decimal'
+                  maximumFractionDigits={2}
+                />
+              )}
+            />
+            <form.Field
+              name={'interestRate'}
+              children={(field) => (
+                <InputNumberFormat
+                  header={t('interestRate')}
+                  placeholder={t('interestRate')}
+                  field={field}
+                  format='percent'
+                  inputMode='decimal'
+                  maximumFractionDigits={2}
+                />
+              )}
+            />
+            <form.Field
+              name={'loanTerm'}
+              children={(field) => (
+                <InputNumberFormat
+                  format='unit'
+                  unit='year'
+                  locales={language}
+                  header={t('loanTerm')}
+                  placeholder={t('loanTerm')}
+                  field={field}
+                  inputMode='numeric'
+                  maximumIntegerDigits={2}
+                />
+              )}
+            />
+          </List>
+        </Section>
+        <Section>
+          <Accordion
+            expanded={additionalOpen}
+            onChange={() => setAdditionalOpen((prev) => !prev)}
+          >
+            <Accordion.Summary>{t('additionalOptions')}</Accordion.Summary>
+            <Accordion.Content>
+              <List>
+                <form.Field
+                  name={'startDate'}
+                  children={(field) => (
+                    <Input
+                      header={t('startDate')}
+                      placeholder={t('startDate')}
+                      field={field}
+                      type='date'
+                    />
+                  )}
+                />
+                <form.Field
+                  name={'paymentType'}
+                  children={(field) => (
+                    <Select
+                      header={t('paymentType')}
+                      field={field}
+                      options={[
+                        {
+                          label: t('annuityPayment'),
+                          value: 'annuity',
+                        },
+                        {
+                          label: t('differentiatedPayment'),
+                          value: 'differentiated',
+                        },
+                      ]}
+                    />
+                  )}
+                />
+                <form.Field
+                  name={'paymentDay'}
+                  children={(field) => (
+                    <Select
+                      header={t('paymentDay')}
+                      field={field}
+                      options={Array.from({ length: 31 }, (_, i) => i + 1).map(
+                        (day) => ({
+                          label: String(day),
+                          value: String(day),
+                        })
+                      )}
+                    />
+                  )}
+                />
+              </List>
+            </Accordion.Content>
+          </Accordion>
+        </Section>
+      </>
     );
   },
 });

--- a/src/components/form/RegularPaymentsForm.tsx
+++ b/src/components/form/RegularPaymentsForm.tsx
@@ -4,10 +4,17 @@ import { useLocalization } from '@/providers/LocalizationProvider';
 import InputNumberFormat from '@/components/ui/InputNumberFormat';
 import Select from '@/components/ui/Select';
 import Input from '@/components/ui/Input';
+import { popup } from '@telegram-apps/sdk-react';
 import { formOpts, withForm } from '@/hooks/useLoanForm';
 import { regularPaymentSchema } from '@/schemas/regularPayment';
 import { loanDetailsSchema } from '@/schemas/loanDetails';
-import { hapticButton, hapticSuccess, hapticSelection, hapticDestructive } from '@/utils/haptic';
+import {
+  hapticButton,
+  hapticSuccess,
+  hapticSelection,
+  hapticDestructive,
+  hapticWarning,
+} from '@/utils/haptic';
 
 const typeLabels: Record<string, string> = {
   reduceTerm: 'typeReduceTerm',
@@ -64,8 +71,12 @@ const RegularPaymentsForm = withForm({
                 expanded={sectionOpen && isLoanDetailsValid}
                 onChange={() => {
                   if (isLoanDetailsValid) {
-                    hapticSelection();
                     setSectionOpen((prev) => !prev);
+                  } else {
+                    hapticWarning();
+                    if (popup.isSupported()) {
+                      popup.show({ message: t('fillLoanDetailsFirst') });
+                    }
                   }
                 }}
               >
@@ -83,7 +94,7 @@ const RegularPaymentsForm = withForm({
                     </form.Field>
                   </>
                 </Accordion.Summary>
-                <Accordion.Content style={{ background: 'transparent' }}>
+                <Accordion.Content>
                   <form.Field name='regularPayments' mode='array'>
                 {(field) => {
                   const expandedItem =

--- a/src/localization/translations.ts
+++ b/src/localization/translations.ts
@@ -27,6 +27,7 @@ export const translations = {
     paymentDay: 'Payment Day',
     paymentDayMonthly: 'Same day as start date',
     paymentDaySpecific: 'Specific day of month',
+    additionalOptions: 'Additional options',
 
     // Results
     paymentSummary: 'Payment Summary',
@@ -45,6 +46,7 @@ export const translations = {
     typeReduceTerm: 'Reduce Term',
     typeReducePayment: 'Reduce Payment',
     addEarlyPayment: 'Add Early Payment',
+    fillLoanDetailsFirst: 'Please fill in the loan amount, interest rate and term to add early or regular payments.',
     earlyPaymentList: 'Scheduled Early Payments',
     remove: 'Remove',
     paymentHistory: 'Early Payments',
@@ -178,6 +180,7 @@ export const translations = {
     paymentDay: 'День платежа',
     paymentDayMonthly: 'В тот же день, что и дата начала',
     paymentDaySpecific: 'Конкретный день месяца',
+    additionalOptions: 'Дополнительные параметры',
 
     // Results
     paymentSummary: 'Сводка по платежам',
@@ -196,6 +199,7 @@ export const translations = {
     typeReduceTerm: 'Сократить срок',
     typeReducePayment: 'Уменьшить платеж',
     addEarlyPayment: 'Добавить досрочный платеж',
+    fillLoanDetailsFirst: 'Сначала укажите сумму кредита, ставку и срок, чтобы добавить досрочные или регулярные платежи.',
     earlyPaymentList: 'Запланированные досрочные платежи',
     remove: 'Удалить',
     paymentHistory: 'Досрочные платежи',


### PR DESCRIPTION
## TASK-33

### Changes
- **Loan form (LoanDetailsForm):** Only amount, rate and term visible; date, payment type and payment day moved into collapsible «Additional options» accordion.
- **Early payments / Regular payments accordions:** When user taps while accordion is disabled (main loan fields invalid), show popup with explanation (`fillLoanDetailsFirst`) and haptic warning.

### Translations
- `additionalOptions` (EN/RU) for the new accordion title.
- `fillLoanDetailsFirst` (EN/RU) for the disabled-accordion message.